### PR TITLE
Restore host llvm-config for LLVM cross builds

### DIFF
--- a/.github/workflows/llvm-prebuilt.yml
+++ b/.github/workflows/llvm-prebuilt.yml
@@ -178,12 +178,13 @@ jobs:
       - name: Build LLVM host tools
         shell: pwsh
         run: |
-          cmake --build llvm-host --target llvm-tblgen clang-tblgen clang-tidy-confusable-chars-gen llvm-nm llvm-readobj
+          cmake --build llvm-host --target llvm-tblgen clang-tblgen llvm-config clang-tidy-confusable-chars-gen llvm-nm llvm-readobj
           $HostBinPath = "$Env:GITHUB_WORKSPACE/llvm-host/bin"
           $ExeExt = if ($IsWindows) { ".exe" } else { "" }
           echo "LLVM_NATIVE_TOOL_DIR=$HostBinPath" >> $Env:GITHUB_ENV
           echo "LLVM_TABLEGEN=$HostBinPath/llvm-tblgen$ExeExt" >> $Env:GITHUB_ENV
           echo "CLANG_TABLEGEN=$HostBinPath/clang-tblgen$ExeExt" >> $Env:GITHUB_ENV
+          echo "LLVM_CONFIG_PATH=$HostBinPath/llvm-config$ExeExt" >> $Env:GITHUB_ENV
           echo "LLVM_VERSION=${{matrix.version}}" >> $Env:GITHUB_ENV
 
       - name: Free disk space after host tools build


### PR DESCRIPTION
## Summary
- restore `llvm-config` to the native host-tools build
- restore `LLVM_CONFIG_PATH` export for target LLVM configures
- keep the rest of the host-tools optimization intact

## Why
The optimized workflow removed host `llvm-config`, but cross-compiling LLVM still expects it. Without `LLVM_CONFIG_PATH`, the Windows arm64 target build created a `llvm-build/NATIVE` subbuild under the arm64 MSVC environment; that produced ARM64 native helper executables like `llvm-min-tblgen.exe`, which then failed when the x64 runner tried to execute them.

This puts back only the host `llvm-config` piece needed to prevent that incompatible NATIVE subbuild.

## Validation
- parsed `.github/workflows/llvm-prebuilt.yml` as YAML
- ran `git diff --check`
- confirmed the fixup diff against `master` is only the host `llvm-config` target/export restoration