### PR TITLE
Reduce LLVM build targets

### DIFF
--- a/cmake/llvm-distribution.cmake
+++ b/cmake/llvm-distribution.cmake
@@ -38,11 +38,7 @@ set(LLVM_TARGETS_TO_BUILD
     "X86"
     "ARM"
     "AArch64"
-    "Mips"
-    "PowerPC"
     "RISCV"
-    "NVPTX"
-    "Hexagon"
     "WebAssembly"
     CACHE STRING "")
 


### PR DESCRIPTION
## Summary
- limit LLVM target backends to X86, ARM, AArch64, RISCV, and WebAssembly
- remove Mips, PowerPC, NVPTX, and Hexagon from distribution builds

## Validation
- inspected final CMake target list and git diff