### PR TITLE
Add slim clang-apple-cross toolchain workflow and release integration

### DIFF
--- a/.github/workflows/clang-apple-cross.yml
+++ b/.github/workflows/clang-apple-cross.yml
@@ -1,0 +1,126 @@
+name: clang-apple-cross
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - friendly-couscous
+    paths:
+      - ".github/workflows/clang-apple-cross.yml"
+      - "cmake/clang-apple-cross.cmake"
+
+jobs:
+  build:
+    name: clang-apple-cross ${{matrix.version}} [${{matrix.arch}}-${{matrix.os}}]
+    runs-on: ${{matrix.runner}}
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ x86_64 ]
+        os: [ ubuntu-22.04, ubuntu-24.04 ]
+        version: [ 22.1.4 ]
+
+        include:
+          - version: 22.1.4
+            ref: llvmorg-22.1.4
+          - os: ubuntu-22.04
+            runner: ubuntu-22.04
+          - os: ubuntu-24.04
+            runner: ubuntu-24.04
+
+    steps:
+      - name: Clone project
+        uses: actions/checkout@v6
+        with:
+          path: llvm-prebuilt
+
+      - name: Configure Linux runner
+        if: runner.os == 'Linux'
+        shell: pwsh
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y zstd xz-utils
+          sudo apt-get install -y ninja-build
+          sudo apt-get install -y libxml2-dev zlib1g-dev
+
+      - name: Clone LLVM ${{matrix.version}}
+        uses: actions/checkout@v6
+        with:
+          repository: llvm/llvm-project
+          ref: ${{matrix.ref}}
+          path: llvm-project
+
+      - name: Configure LLVM host tools
+        shell: pwsh
+        run: |
+          $CMakeArgs = @(
+            "-DLLVM_TARGETS_TO_BUILD=Native",
+            "-DLLVM_ENABLE_PROJECTS=clang;llvm",
+            "-DLLVM_ENABLE_RUNTIMES=",
+            "-DLLVM_ENABLE_LIBXML2=OFF",
+            "-DLLVM_ENABLE_ZLIB=OFF",
+            "-DLLVM_ENABLE_ZSTD=OFF",
+            "-DLLVM_ENABLE_TERMINFO=OFF",
+            "-DLLVM_ENABLE_Z3_SOLVER=OFF",
+            "-DLLVM_INCLUDE_DOCS=OFF",
+            "-DLLVM_INCLUDE_TESTS=OFF",
+            "-DLLVM_INCLUDE_BENCHMARKS=OFF",
+            "-DLLVM_INCLUDE_EXAMPLES=OFF",
+            "-DLLVM_INCLUDE_GO_TESTS=OFF",
+            "-DCMAKE_BUILD_TYPE=Release"
+          )
+
+          cmake -G Ninja -S llvm-project/llvm -B llvm-host $CMakeArgs -Wno-dev
+
+      - name: Build LLVM host tools
+        shell: pwsh
+        run: |
+          cmake --build llvm-host --target llvm-tblgen clang-tblgen llvm-config
+          $HostBinPath = "$Env:GITHUB_WORKSPACE/llvm-host/bin"
+          $ExeExt = ""
+          echo "LLVM_NATIVE_TOOL_DIR=$HostBinPath" >> $Env:GITHUB_ENV
+          echo "LLVM_TABLEGEN=$HostBinPath/llvm-tblgen$ExeExt" >> $Env:GITHUB_ENV
+          echo "CLANG_TABLEGEN=$HostBinPath/clang-tblgen$ExeExt" >> $Env:GITHUB_ENV
+          echo "LLVM_CONFIG_PATH=$HostBinPath/llvm-config$ExeExt" >> $Env:GITHUB_ENV
+          echo "LLVM_VERSION=${{matrix.version}}" >> $Env:GITHUB_ENV
+
+      - name: Free disk space after host tools build
+        if: runner.os == 'Linux'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path llvm-host-tools -Force | Out-Null
+          Copy-Item -Path llvm-host/bin/* -Destination llvm-host-tools/ -Recurse -Force
+          Remove-Item -Path llvm-host -Recurse -Force
+          New-Item -ItemType Directory -Path llvm-host/bin -Force | Out-Null
+          Copy-Item -Path llvm-host-tools/* -Destination llvm-host/bin/ -Recurse -Force
+          Remove-Item -Path llvm-host-tools -Recurse -Force
+          & df -h
+
+      - name: Configure LLVM
+        shell: pwsh
+        run: |
+          $TargetName = "${{matrix.arch}}-${{matrix.os}}"
+          $CMakeToolchainFile = "$Env:GITHUB_WORKSPACE/llvm-prebuilt/cmake/$TargetName.cmake"
+          $CMakeInitialCache = "$Env:GITHUB_WORKSPACE/llvm-prebuilt/cmake/clang-apple-cross.cmake"
+
+          cmake -G Ninja -S llvm-project/llvm -B llvm-build `
+            -DCMAKE_INSTALL_PREFIX=llvm-install `
+            -DCMAKE_TOOLCHAIN_FILE="$CMakeToolchainFile" `
+            -C $CMakeInitialCache -Wno-dev
+
+      - name: Build LLVM
+        run: cmake --build llvm-build
+
+      - name: Install LLVM
+        run: cmake --build llvm-build --target install-distribution
+
+      - name: Package LLVM
+        run: |
+          mv llvm-install clang-apple-cross-${{matrix.version}}-${{matrix.arch}}-${{matrix.os}}
+          tar -cJf clang-apple-cross-${{matrix.version}}-${{matrix.arch}}-${{matrix.os}}.tar.xz clang-apple-cross-${{matrix.version}}-${{matrix.arch}}-${{matrix.os}}
+
+      - name: Upload LLVM package
+        uses: actions/upload-artifact@v7
+        with:
+          name: clang-apple-cross-${{matrix.version}}-${{matrix.arch}}-${{matrix.os}}
+          path: clang-apple-cross-${{matrix.version}}-${{matrix.arch}}-${{matrix.os}}.tar.xz

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -22,6 +22,10 @@ on:
         description: 'cctools workflow run id'
         default: "latest"
         required: true
+      clang_apple_cross_run_id:
+        description: 'clang-apple-cross workflow run id'
+        default: "latest"
+        required: true
       dry-run:
         description: 'dry run (skip release)'
         required: true
@@ -95,6 +99,22 @@ jobs:
           $Workflow = "cctools prebuilt"
           $Repository = $Env:GITHUB_REPOSITORY
           $RunId = '${{ github.event.inputs.cctools_run_id }}'
+          if ($RunId -eq 'latest') {
+            $RunId = $(gh run list -R $Repository -w $Workflow --json 'status,databaseId,conclusion') |
+              ConvertFrom-Json | Where-Object { ($_.status -eq 'completed') -and ($_.conclusion -eq 'success') } |
+              Select-Object -First 1 -ExpandProperty databaseId
+          }
+          Write-Host "Downloading run $RunId ($Workflow)"
+          & gh run download -R $Repository $RunId
+
+      - name: Download clang-apple-cross
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $Workflow = "clang-apple-cross"
+          $Repository = $Env:GITHUB_REPOSITORY
+          $RunId = '${{ github.event.inputs.clang_apple_cross_run_id }}'
           if ($RunId -eq 'latest') {
             $RunId = $(gh run list -R $Repository -w $Workflow --json 'status,databaseId,conclusion') |
               ConvertFrom-Json | Where-Object { ($_.status -eq 'completed') -and ($_.conclusion -eq 'success') } |

--- a/cmake/clang-apple-cross.cmake
+++ b/cmake/clang-apple-cross.cmake
@@ -38,8 +38,9 @@ endif()
 
 set(PACKAGE_VENDOR "awakecoding" CACHE STRING "")
 
-# Apple arm64 only: no Intel Mac, no iOS simulator x64, no other backends.
+# Apple x86_64 and arm64: no other backends.
 set(LLVM_TARGETS_TO_BUILD
+    "X86"
     "AArch64"
     CACHE STRING "")
 

--- a/cmake/clang-apple-cross.cmake
+++ b/cmake/clang-apple-cross.cmake
@@ -1,0 +1,112 @@
+# Slim Clang toolchain for cross-building Apple arm64 binaries from Linux x86_64.
+# This cache intentionally omits LLVM libraries, headers, CMake exports,
+# clang-tools-extra, llc/lli/opt, runtimes, and any tool not needed for a
+# fake Xcode cross-build layout.
+
+if(DEFINED ENV{CMAKE_INSTALL_PREFIX})
+    set(CMAKE_INSTALL_PREFIX $ENV{CMAKE_INSTALL_PREFIX} CACHE FILEPATH "")
+endif()
+
+if(DEFINED ENV{LLVM_NATIVE_TOOL_DIR})
+    set(LLVM_NATIVE_TOOL_DIR $ENV{LLVM_NATIVE_TOOL_DIR} CACHE FILEPATH "")
+    message(STATUS "LLVM_NATIVE_TOOL_DIR: ${LLVM_NATIVE_TOOL_DIR}")
+endif()
+
+if(DEFINED ENV{CLANG_TABLEGEN})
+    set(CLANG_TABLEGEN $ENV{CLANG_TABLEGEN} CACHE FILEPATH "")
+    message(STATUS "CLANG_TABLEGEN: ${CLANG_TABLEGEN}")
+endif()
+
+if(DEFINED ENV{LLVM_TABLEGEN})
+    set(LLVM_TABLEGEN $ENV{LLVM_TABLEGEN} CACHE FILEPATH "")
+    message(STATUS "LLVM_TABLEGEN: ${LLVM_TABLEGEN}")
+endif()
+
+if(DEFINED ENV{LLVM_CONFIG_PATH})
+    set(LLVM_CONFIG_PATH $ENV{LLVM_CONFIG_PATH} CACHE FILEPATH "")
+    message(STATUS "LLVM_CONFIG_PATH: ${LLVM_CONFIG_PATH}")
+endif()
+
+if(DEFINED ENV{LLVM_VERSION})
+    set(LLVM_VERSION $ENV{LLVM_VERSION} CACHE FILEPATH "")
+    message(STATUS "LLVM_VERSION: ${LLVM_VERSION}")
+endif()
+
+if(CMAKE_INSTALL_PREFIX)
+    message(STATUS "CMAKE_INSTALL_PREFIX: ${CMAKE_INSTALL_PREFIX}")
+endif()
+
+set(PACKAGE_VENDOR "awakecoding" CACHE STRING "")
+
+# Apple arm64 only: no Intel Mac, no iOS simulator x64, no other backends.
+set(LLVM_TARGETS_TO_BUILD
+    "AArch64"
+    CACHE STRING "")
+
+set(LLVM_ENABLE_PROJECTS
+    "clang"
+    "lld"
+    "llvm"
+    CACHE STRING "")
+
+set(LLVM_ENABLE_RUNTIMES "" CACHE STRING "")
+
+set(LLVM_ENABLE_BACKTRACES OFF CACHE BOOL "")
+set(LLVM_ENABLE_DIA_SDK OFF CACHE BOOL "")
+set(LLVM_ENABLE_TERMINFO OFF CACHE BOOL "")
+set(LLVM_ENABLE_LIBXML2 ON CACHE BOOL "")
+set(LLVM_ENABLE_ZLIB ON CACHE BOOL "")
+set(LLVM_ENABLE_ZSTD OFF CACHE BOOL "")
+set(LLVM_ENABLE_UNWIND_TABLES OFF CACHE BOOL "")
+set(LLVM_ENABLE_Z3_SOLVER OFF CACHE BOOL "")
+set(LLVM_ENABLE_RTTI OFF CACHE BOOL "")
+set(LLVM_ENABLE_EH OFF CACHE BOOL "")
+set(LLVM_INCLUDE_DOCS OFF CACHE BOOL "")
+set(LLVM_INCLUDE_TESTS OFF CACHE BOOL "")
+set(LLVM_INCLUDE_EXAMPLES OFF CACHE BOOL "")
+set(LLVM_INCLUDE_GO_TESTS OFF CACHE BOOL "")
+
+set(LLVM_BUILD_LLVM_C_DYLIB OFF CACHE BOOL "")
+set(LLVM_BUILD_32_BITS OFF CACHE BOOL "")
+
+set(LLVM_ENABLE_ASSERTIONS OFF CACHE BOOL "")
+set(CMAKE_BUILD_TYPE Release CACHE STRING "")
+
+set(LLVM_INSTALL_TOOLCHAIN_ONLY OFF CACHE BOOL "")
+
+# Apple-specific cctools equivalents shipped by LLVM.
+set(LLVM_CCTOOLS_COMPONENTS
+    llvm-lipo
+    llvm-libtool-darwin
+    llvm-install-name-tool
+    llvm-bitcode-strip
+    CACHE STRING "")
+
+# Minimal Mach-O binutils required by the cross-build and fake Xcode layout.
+set(LLVM_BINUTILS_COMPONENTS
+    llvm-ar
+    llvm-cxxfilt
+    llvm-nm
+    llvm-objcopy
+    llvm-objdump
+    llvm-readobj
+    llvm-size
+    llvm-strings
+    llvm-symbolizer
+    CACHE STRING "")
+
+# Core compiler toolchain utilities. Keep only the ones actually used.
+set(LLVM_TOOLCHAIN_TOOLS
+    dsymutil
+    llvm-ranlib
+    llvm-strip
+    ${LLVM_CCTOOLS_COMPONENTS}
+    ${LLVM_BINUTILS_COMPONENTS}
+    CACHE STRING "")
+
+set(LLVM_DISTRIBUTION_COMPONENTS
+    clang
+    clang-resource-headers
+    lld
+    ${LLVM_TOOLCHAIN_TOOLS}
+    CACHE STRING "")


### PR DESCRIPTION
This PR adds a dedicated, slim Clang toolchain for cross-building Apple binaries from Linux x86_64 hosts.

## New workflow: `clang-apple-cross.yml`

- Host: Linux x86_64 (Ubuntu 22.04 and 24.04)
- Target backends: `X86` and `AArch64`
- LLVM version: 22.1.4
- Builds only the tools needed for a fake Xcode cross-build layout:
  - `clang`, `clang++`, `lld`, `ld64.lld`
  - Apple-specific: `dsymutil`, `llvm-lipo`, `llvm-libtool-darwin`, `llvm-install-name-tool`, `llvm-bitcode-strip`
  - Minimal Mach-O binutils: `llvm-ar`, `llvm-ranlib`, `llvm-nm`, `llvm-objcopy`, `llvm-objdump`, `llvm-strip`, `llvm-cxxfilt`, `llvm-size`, `llvm-strings`, `llvm-readobj`, `llvm-symbolizer`
- Omits: LLVM libraries/headers/CMake exports, `clang-tools-extra`, `llc`/`lli`/`opt`, runtimes, and LTO
- Produces `clang-apple-cross-<version>-<arch>-<os>.tar.xz` artifacts (~83-84 MB each)
- Includes an `on: push` trigger for the feature branch so it runs before merging to master

## Release integration

- Updated `github-release.yml` to accept a `clang_apple_cross_run_id` input and download the `clang-apple-cross` artifacts, so they are published alongside LLVM, Halide, and cctools releases.

## New file

- `cmake/clang-apple-cross.cmake` — slim initial cache for the reduced distribution.

## Verification

- Workflow run `28963919673` completed successfully for both Ubuntu 22.04 and 24.04.
- YAML validated with `actionlint`.
- CMake cache parses cleanly.